### PR TITLE
[FIX] Key error in attachment decoding

### DIFF
--- a/bytist_fix_google_font/__manifest__.py
+++ b/bytist_fix_google_font/__manifest__.py
@@ -5,7 +5,7 @@
     'author': "Bytist GmbH",
     'website': "https://bytist.de",
     'category': 'Website',
-    'version': '16.0.1.0.0',
+    'version': '16.0.1.0.1',
     'depends': ['web', 'website'],
     'license': 'OPL-1',
     'support': 'contact@bytist.de',

--- a/bytist_fix_google_font/models/attachment.py
+++ b/bytist_fix_google_font/models/attachment.py
@@ -5,6 +5,7 @@ class IrAttachment(models.Model):
 
     def _postprocess_contents(self, values):
         values = super()._postprocess_contents(values)
-        if values['name'].startswith('web.assets_'):
-            values['raw'] = values['raw'].decode().replace('https://fonts.googleapis.com/css', '/css/font/google').encode()
+        if values.get('name', '').startswith('web.assets_'):
+            if values.get('raw'):
+                values['raw'] = values['raw'].decode().replace('https://fonts.googleapis.com/css', '/css/font/google').encode()
         return values


### PR DESCRIPTION
A bug in the attachment decoding process has been fixed. The code now checks if the 'name' and 'raw' key exists before attempting to decode it, preventing errors when processing certain attachments.